### PR TITLE
Feature/enable kubectl execconfig edit

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -94,7 +94,18 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 				}
 
 			case reflect.TypeOf(&clientcmdapi.ExecConfig{}):
-				return nil, fmt.Errorf("found exec, kubectl config set does not currently support manipulating exec settings")
+				steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
+				currPartIndex += 1
+
+				// If we have a part after the auth provider name we need to add it. There should only ever be at most one part after this.
+				nextPart := strings.Join(individualParts[currPartIndex:], ".")
+				if len(strings.Split(nextPart, ".")) > 1 {
+					return nil, fmt.Errorf("too many steps in path %v", path)
+				} else if len(strings.Split(nextPart, ".")) > 1 {
+					steps = append(steps, navigationStep{individualParts[currPartIndex], reflect.TypeOf("")})
+					currPartIndex += 1
+				}
+				// return nil, fmt.Errorf("steps: %v", steps)
 
 			default:
 				return nil, fmt.Errorf("unable to parse one or more field values of %v", path)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser.go
@@ -51,11 +51,18 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			// This set of reflective code pulls the type of the map values, uses that type to look up the set of legal tags.  Those legal tags are used to
 			// walk the list of remaining parts until we find a match to a legal tag or the end of the string.  That name is used to burn all the used parts.
 			mapValueType := currType.Elem().Elem()
-			mapValueOptions, err := getPotentialTypeValues(mapValueType)
-			if err != nil {
-				return nil, err
+
+			var nextPart string
+			if mapValueType.Kind() != reflect.Struct {
+				mapValueType = currType.Elem()
+				nextPart = strings.Join(individualParts[currPartIndex:], ".")
+			} else {
+				mapValueOptions, err := getPotentialTypeValues(mapValueType)
+				if err != nil {
+					return nil, err
+				}
+				nextPart = findNameStep(individualParts[currPartIndex:], sets.StringKeySet(mapValueOptions))
 			}
-			nextPart := findNameStep(individualParts[currPartIndex:], sets.StringKeySet(mapValueOptions))
 
 			steps = append(steps, navigationStep{nextPart, mapValueType})
 			currPartIndex += len(strings.Split(nextPart, "."))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/navigation_step_parser_test.go
@@ -72,18 +72,6 @@ func TestParseWithBadValue(t *testing.T) {
 	test.run(t)
 }
 
-func TestParseWithNoMatchingValue(t *testing.T) {
-	test := stepParserTest{
-		path: "users.jheiss.exec.command",
-		expectedNavigationSteps: navigationSteps{
-			steps: []navigationStep{},
-		},
-		expectedError: "found exec, kubectl config set does not currently support manipulating exec settings",
-	}
-
-	test.run(t)
-}
-
 func (test stepParserTest) run(t *testing.T) {
 	actualSteps, err := newNavigationSteps(test.path)
 	if len(test.expectedError) != 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -160,7 +160,7 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 	switch actualCurrValue.Kind() {
 	case reflect.Map:
 		if !steps.moreStepsRemaining() && !unset {
-			if currStep.stepType == nil{
+			if currStep.stepType == nil {
 				return fmt.Errorf("map key required to set value")
 			}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -224,11 +224,6 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 			return fmt.Errorf("can't have more steps after slice. %v", steps)
 		}
 
-		if unset && steps.steps[steps.currentStepIndex-2].stepValue != "env" {
-			actualCurrValue.Set(reflect.Zero(actualCurrValue.Type()))
-			return nil
-		}
-
 		if setRawBytes {
 			actualCurrValue.SetBytes([]byte(propertyValue))
 		} else {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -159,6 +159,10 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 	switch actualCurrValue.Kind() {
 	case reflect.Map:
 		if !steps.moreStepsRemaining() && !unset {
+			if currStep.stepType == nil{
+				return fmt.Errorf("map key required to set value")
+			}
+
 			// If the current step type is a Slice we will attempt to set using this
 			if currStep.stepType.Kind() == reflect.Slice {
 				mapKey := reflect.ValueOf(currStep.stepValue)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -241,6 +241,11 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 					if !ok {
 						return fmt.Errorf("error fetching existing args slice")
 					}
+					for _, arg := range argSlice {
+						if propertyValue == arg {
+							return fmt.Errorf("arg already exists")
+						}
+					}
 
 					slice = append(slice, argSlice...)
 					actualCurrValue.Set(reflect.ValueOf(slice))
@@ -249,7 +254,11 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 				default:
 					// Set arg array to supplied values
 					argSlice := strings.Split(propertyValue, ",")
-					actualCurrValue.Set(reflect.ValueOf(argSlice))
+
+					// Dedupe array using slice to map to slice conversion
+					dedupeArgs := dedupeStringSlice(argSlice)
+
+					actualCurrValue.Set(reflect.ValueOf(dedupeArgs))
 					return nil
 				}
 			} else if innerKind == reflect.Struct {
@@ -520,4 +529,16 @@ func getExecConfigEnvByName(v reflect.Value, name string) int {
 
 	// If we never find the Name key return false
 	return -1
+}
+
+func dedupeStringSlice(slice []string) []string {
+	sliceMap := make(map[string]struct{})
+	for i := 0; i < len(slice); i++ {
+		sliceMap[slice[i]] = struct{}{}
+	}
+	var dedupeSlice []string
+	for k := range sliceMap {
+		dedupeSlice = append(dedupeSlice, k)
+	}
+	return dedupeSlice
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -511,6 +512,7 @@ func dedupeStringSlice(slice []string) []string {
 	for k := range sliceMap {
 		dedupeSlice = append(dedupeSlice, k)
 	}
+	sort.Strings(dedupeSlice)
 	return dedupeSlice
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -119,6 +119,1128 @@ func TestSetConfigAuthProviderConfigRefreshToken(t *testing.T) {
 	test.run(t)
 }
 
+func TestSetConfigExecConfigCommand(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Command: "test",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.command to test",
+		config:         conf,
+		args:           []string{"users.foo.exec.command", "test"},
+		expected:       `Property "users.foo.exec.command" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecArgsNew(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.args to test1,test2,test3",
+		config:         conf,
+		args:           []string{"users.foo.exec.args", "test1,test2,test3"},
+		expected:       `Property "users.foo.exec.args" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecArgsAdd(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+						"test4",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.args to test4+",
+		config:         conf,
+		args:           []string{"users.foo.exec.args", "test4+"},
+		expected:       `Property "users.foo.exec.args" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecArgsDelete(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.args to test2-",
+		config:         conf,
+		args:           []string{"users.foo.exec.args", "test2-"},
+		expected:       `Property "users.foo.exec.args" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecArgsUpdate(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test2",
+						"test3",
+						"test4",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Args: []string{
+						"test1",
+						"test3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.args to test1,test3",
+		config:         conf,
+		args:           []string{"users.foo.exec.args", "test1,test3"},
+		expected:       `Property "users.foo.exec.args" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecProvideClusterInfo(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					ProvideClusterInfo: true,
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.provideClusterInfo to true",
+		config:         conf,
+		args:           []string{"users.foo.exec.provideClusterInfo", "true"},
+		expected:       `Property "users.foo.exec.provideClusterInfo" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecEnvNew(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Env: []clientcmdapi.ExecEnvVar{
+						{
+							Name:  "test",
+							Value: "value",
+						},
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.env.test to value",
+		config:         conf,
+		args:           []string{"users.foo.exec.env.test", "value"},
+		expected:       `Property "users.foo.exec.env.test" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigExecEnvUpdate(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Env: []clientcmdapi.ExecEnvVar{
+						{
+							Name:  "test",
+							Value: "value1",
+						},
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					Env: []clientcmdapi.ExecEnvVar{
+						{
+							Name:  "test",
+							Value: "value2",
+						},
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.env.test to value2",
+		config:         conf,
+		args:           []string{"users.foo.exec.env.test", "value2"},
+		expected:       `Property "users.foo.exec.env.test" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigInstallHint(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					InstallHint: "test",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.installHint to test",
+		config:         conf,
+		args:           []string{"users.foo.exec.installHint", "test"},
+		expected:       `Property "users.foo.exec.installHint" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigInteractiveMode(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Exec: &clientcmdapi.ExecConfig{
+					InteractiveMode: "Never",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.exec.interactiveMode to Never",
+		config:         conf,
+		args:           []string{"users.foo.exec.interactiveMode", "Never"},
+		expected:       `Property "users.foo.exec.interactiveMode" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUser(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Impersonate: "test1",
+				Extensions:  map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as to test1",
+		config:         conf,
+		args:           []string{"users.foo.act-as", "test1"},
+		expected:       `Property "users.foo.act-as" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUID(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUID: "1000",
+				Extensions:     map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as to 1000",
+		config:         conf,
+		args:           []string{"users.foo.act-as-uid", "1000"},
+		expected:       `Property "users.foo.act-as-uid" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateGroupsNew(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-groups to test1,test2,test3",
+		config:         conf,
+		args:           []string{"users.foo.act-as-groups", "test1,test2,test3"},
+		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateGroupsAdd(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+					"test4",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-groups to test4+",
+		config:         conf,
+		args:           []string{"users.foo.act-as-groups", "test4+"},
+		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateGroupsDelete(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-groups to test3-",
+		config:         conf,
+		args:           []string{"users.foo.act-as-groups", "test3-"},
+		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateGroupsUpdate(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test1",
+					"test2",
+					"test3",
+					"test4",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateGroups: []string{
+					"test8",
+					"test9",
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-groups to test8,test9",
+		config:         conf,
+		args:           []string{"users.foo.act-as-groups", "test8,test9"},
+		expected:       `Property "users.foo.act-as-groups" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUserExtraNew(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val1,val2,val3",
+		config:         conf,
+		args:           []string{"users.foo.act-as-user-extra.test1", "val1,val2,val3"},
+		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUserExtraAdd(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+						"val4",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val4+",
+		config:         conf,
+		args:           []string{"users.foo.act-as-user-extra.test1", "val4+"},
+		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUserExtraDelete(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val3-",
+		config:         conf,
+		args:           []string{"users.foo.act-as-user-extra.test1", "val3-"},
+		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUserExtraUpdate(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val5",
+						"val6",
+						"val7",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test1 to val5,val6,val7",
+		config:         conf,
+		args:           []string{"users.foo.act-as-user-extra.test1", "val5,val6,val7"},
+		expected:       `Property "users.foo.act-as-user-extra.test1" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigImpersonateUserExtraNewKey(t *testing.T) {
+	conf := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ImpersonateUserExtra: map[string][]string{
+					"test1": {
+						"val1",
+						"val2",
+						"val3",
+					},
+					"test2": {
+						"val1",
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.act-as-user-extra.test2 to val1",
+		config:         conf,
+		args:           []string{"users.foo.act-as-user-extra.test2", "val1"},
+		expected:       `Property "users.foo.act-as-user-extra.test2" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigUsername(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Username:   "test1",
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.username to test1",
+		config:         conf,
+		args:           []string{"users.foo.username", "test1"},
+		expected:       `Property "users.foo.username" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigPassword(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Password:   "abadpassword",
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.password to abadpassword",
+		config:         conf,
+		args:           []string{"users.foo.password", "abadpassword"},
+		expected:       `Property "users.foo.password" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigClientCertificate(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ClientCertificate: "./file/path",
+				Extensions:        map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.client-certificate to ./file/path",
+		config:         conf,
+		args:           []string{"users.foo.client-certificate", "./file/path"},
+		expected:       `Property "users.foo.client-certificate" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigClientCertificateData(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ClientCertificateData: []byte("not real cert data"),
+				Extensions:            map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.client-certificate-data to not real cert data",
+		config:         conf,
+		args:           []string{"users.foo.client-certificate-data", "--set-raw-bytes=true", "not real cert data"},
+		expected:       `Property "users.foo.client-certificate-data" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigClientKey(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ClientKey:  "./file/path",
+				Extensions: map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.client-key to ./file/path",
+		config:         conf,
+		args:           []string{"users.foo.client-key", "./file/path"},
+		expected:       `Property "users.foo.client-key" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigClientKeyData(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				ClientKeyData: []byte("not real key data"),
+				Extensions:    map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.client-key-data to not real key data",
+		config:         conf,
+		args:           []string{"users.foo.client-key-data", "--set-raw-bytes=true", "not real key data"},
+		expected:       `Property "users.foo.client-key-data" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigToken(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				Token: "fake token data",
+				Extensions:    map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.token to fake token data",
+		config:         conf,
+		args:           []string{"users.foo.token", "fake token data"},
+		expected:       `Property "users.foo.token" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
+func TestSetConfigTokenFile(t *testing.T) {
+	conf := *clientcmdapi.NewConfig()
+	expectedConfig := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"foo": {
+				TokenFile: "./file/path",
+				Extensions:    map[string]runtime.Object{},
+			},
+		},
+		Clusters:   map[string]*clientcmdapi.Cluster{},
+		Contexts:   map[string]*clientcmdapi.Context{},
+		Extensions: map[string]runtime.Object{},
+		Preferences: clientcmdapi.Preferences{
+			Colors:     false,
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+	expectedConfig.Extensions = map[string]runtime.Object{}
+	test := setConfigTest{
+		description:    "Testing for kubectl config set users.foo.tokenFile to ./file/path",
+		config:         conf,
+		args:           []string{"users.foo.tokenFile", "./file/path"},
+		expected:       `Property "users.foo.tokenFile" set.` + "\n",
+		expectedConfig: expectedConfig,
+	}
+	test.run(t)
+}
+
 func (test setConfigTest) run(t *testing.T) {
 	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_test.go
@@ -24,6 +24,7 @@ import (
 
 	"reflect"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -148,7 +149,7 @@ func (test setConfigTest) run(t *testing.T) {
 			if test.expectedConfig.AuthInfos[k] != nil && config.AuthInfos[k] != nil {
 				test.expectedConfig.AuthInfos[k].LocationOfOrigin = config.AuthInfos[k].LocationOfOrigin
 			} else {
-				t.Errorf("Failed in:%q\n cannot find key %v in either expectedConfig or config", test.description, k)
+				t.Errorf("Failed in:%q\n cannot find key %v in AuthInfos map for expectedConfig and/or config", test.description, k)
 			}
 		}
 	}
@@ -159,6 +160,6 @@ func (test setConfigTest) run(t *testing.T) {
 		}
 	}
 	if !reflect.DeepEqual(*config, test.expectedConfig) {
-		t.Errorf("Failed in: %q\n expected %#v\n but got %#v", test.description, *config, test.expectedConfig)
+		t.Errorf("config want/got mismatch (-want +got):\n%s", cmp.Diff(test.expectedConfig, *config))
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/unset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/unset.go
@@ -84,7 +84,7 @@ func (o unsetOptions) run(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	err = modifyConfig(reflect.ValueOf(config), steps, "", true, true)
+	err = modifyConfig(reflect.ValueOf(config), steps, "", true, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Enable `kubectl config set` to edit keys under the `users.foo.exec` path.

#### Which issue(s) this PR fixes:
Fixes kubernetes/kubectl#1165

#### Does this PR introduce a user-facing change?
```release-note
enable users to set configuration settings under users.foo.exec
```
